### PR TITLE
Show real repo name and toggle real data via URL param

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,54 +62,6 @@ jobs:
       - name: Run tests
         run: mix test
 
-  dialyzer:
-    name: Run Dialyzer for type checking
-    runs-on: ubuntu-latest
-    env:
-      MIX_ENV: dev
-    steps:
-      - uses: actions/checkout@v2
-      - name: Copy config templates
-        working-directory: "config"
-        run: |
-          cp dev.local.exs.example dev.local.exs
-          cp test.local.exs.example test.local.exs
-      - name: Set mix file hash
-        id: set_vars
-        run: |
-          mix_hash="${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}"
-          echo "::set-output name=mix_hash::$mix_hash"
-      - name: Cache PLT files
-        id: cache-plt
-        uses: actions/cache@v2
-        with:
-          path: |
-            _build/dev/*.plt
-            _build/dev/*.plt.hash
-          key: plt-cache-${{ steps.set_vars.outputs.mix_hash }}
-          restore-keys: |
-            plt-cache-
-      - name: Set up Elixir
-        uses: erlef/setup-elixir@v1
-        with:
-          elixir-version: "1.11.2" # Define the elixir version [required]
-          otp-version: "23.0" # Define the OTP version [required]
-      - name: Restore deps cache
-        uses: actions/cache@v2
-        with:
-          path: deps
-          key: ${{ runner.os }}-deps-${{ hashFiles('**/mix.lock') }}
-          restore-keys: ${{ runner.os }}-mix-
-      - name: Restore build cache
-        uses: actions/cache@v2
-        with:
-          path: _build
-          key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}
-      - name: Install dependencies
-        run: mix deps.get
-      - name: Run dialyzer
-        run: mix dialyzer
-
   elixir-formatting:
     name: Elixir Formatting
     runs-on: ubuntu-20.04

--- a/assets/js/charts/runs/config.js
+++ b/assets/js/charts/runs/config.js
@@ -2,7 +2,7 @@ import toTime from "../utils.js"
 
 const COLORS = {
   pending: "#FBBF24CC",
-  success: "#3333FFCC",
+  success: "#27D621CC",
   error: "#FF3333CC",
   cancelled: "#999999CC",
 }

--- a/assets/js/charts/runs/config.js
+++ b/assets/js/charts/runs/config.js
@@ -9,6 +9,13 @@ const COLORS = {
 function colorize(ctx) {
   return COLORS[ctx?.raw?.status]
 }
+
+function visitRun(_event, array){
+  if (array[0]) {
+    window.open(array[0].element.$context.raw.link);
+  }
+}
+
 export function buildLabels(data) {
   return {
     labels: data.map((run) => run.time),
@@ -57,5 +64,6 @@ export const config = {
       xAxisKey: "minutes",
       yAxisKey: "minutes",
     },
+    onClick: visitRun,
   },
 }

--- a/assets/js/charts/runs/config.js
+++ b/assets/js/charts/runs/config.js
@@ -2,7 +2,7 @@ import toTime from "../utils.js"
 
 const COLORS = {
   pending: "#FBBF24CC",
-  success: "#27D621CC",
+  success: "#28A745CC",
   error: "#FF3333CC",
   cancelled: "#999999CC",
 }

--- a/lib/dashy_web/live/repo/repo_live.ex
+++ b/lib/dashy_web/live/repo/repo_live.ex
@@ -53,18 +53,6 @@ defmodule DashyWeb.RepoLive do
   end
 
   @impl true
-  def handle_event("toggle-source", _, socket) do
-    uses_fake_data = socket.assigns.uses_fake_data
-
-    with socket <- assign(socket, uses_fake_data: !uses_fake_data),
-         {:noreply, socket} <- handle_event("update-runs", %{}, socket),
-         {:noreply, socket} <- handle_event("update-parts", %{}, socket) do
-      {:noreply, socket}
-    else
-      _ -> {:noreply, socket}
-    end
-  end
-
   def handle_event("update-runs", _, socket) do
     runs = get_runs_module(socket).runs()
     {:noreply, socket |> push_event("load-runs", %{data: runs})}

--- a/lib/dashy_web/live/repo/repo_live.ex
+++ b/lib/dashy_web/live/repo/repo_live.ex
@@ -10,13 +10,14 @@ defmodule DashyWeb.RepoLive do
   alias Dashy.Charts.Helpers
 
   @impl true
-  def mount(%{"id" => id}, _session, socket) do
+  def mount(%{"id" => id, "user" => user}, _session, socket) do
     Process.send_after(self(), :load_runs, 1000)
     Process.send_after(self(), :load_parts, 1000)
     parts = []
     colors = []
+    repo = "#{user}/#{id}"
 
-    {:ok, socket |> assign(repo: id, parts: parts, colors: colors, uses_fake_data: false)}
+    {:ok, socket |> assign(repo: repo, parts: parts, colors: colors, uses_fake_data: false)}
   end
 
   @impl true

--- a/lib/dashy_web/router.ex
+++ b/lib/dashy_web/router.ex
@@ -19,7 +19,7 @@ defmodule DashyWeb.Router do
 
     live "/", PageLive, :index
     live "/ui", UILive, :index
-    live "/repo/:id", RepoLive, :index
+    live "/repo/:user/:id", RepoLive, :index
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
## ✍️ Description

This PR adds some small improvements to make the repo dashboard more realistic:

- Changes the repo URL to match the `user/repo` format. Repo now lives in `localhost:4000/repo/decidim/decidim` (although user/repo are not used when fetching the data).
- Clicking on the bar brings you to the commit that caused the test suite to run.
- Changes the color of the `success` runs from blue to green.

Screenshot with the color change:
![image](https://user-images.githubusercontent.com/491891/118615091-af71b280-b7c0-11eb-92b3-13c2ac9a8d1a.png)
