### PR TITLE
Group jobs on parts charts data query

### DIFF
--- a/assets/js/charts/runs/config.js
+++ b/assets/js/charts/runs/config.js
@@ -10,9 +10,9 @@ function colorize(ctx) {
   return COLORS[ctx?.raw?.status]
 }
 
-function visitRun(_event, array){
+function visitRun(_event, array) {
   if (array[0]) {
-    window.open(array[0].element.$context.raw.link);
+    window.open(array[0].element.$context.raw.link)
   }
 }
 


### PR DESCRIPTION
## ✍️ Description
This PR fixes the Parts chart data query, to group all jobs for the same workflow into one point

## ✅ Fixes

(optional)

- Closes #(issue)
- Fixes #(issue)

## ✅ QA

Before requesting a review, please make sure that:

- [ ] Preview is working on Netlify, Heroku or similar.
- [ ] Manually check that it's working.
- [ ] Add documentation and tests if needed.

## 📸 Screenshots

(optional) Please post any relevant screenshots that might help understanding the scope of this functionality.

## 🔗 Relevant URLs

(optional)

* https://example.com/feature/1
* https://example.com/feature/2

## 📕Extra Documentation

(optional)

Please include links to any external documentation such as requirements, manuals, etc.
