### PR TITLE
Precalculate run times during fetch

### DIFF
--- a/lib/dashy/charts/workflow_parts.ex
+++ b/lib/dashy/charts/workflow_parts.ex
@@ -1,7 +1,6 @@
 defmodule Dashy.Charts.WorkflowParts do
   alias Dashy.Charts.Part
   alias Dashy.WorkflowRuns.WorkflowRun
-  alias Dashy.WorkflowRunJobs.WorkflowRunJob
 
   alias Dashy.Repo
   import Ecto.Query
@@ -14,60 +13,57 @@ defmodule Dashy.Charts.WorkflowParts do
     days = Keyword.get(opts, :days, 30)
     minimum_start_time = last.created_at |> DateTime.add(-days * 60 * 60 * 24, :second)
 
-    grouped_run_jobs =
+    grouped_runs =
       from(
-        j in WorkflowRunJob,
-        join: r in WorkflowRun,
-        on: r.external_id == j.workflow_run_id,
+        r in WorkflowRun,
         select: %{
-          name: fragment("array_agg(?)", r.name),
-          started_at: min(j.started_at),
-          completed_at: max(j.completed_at),
+          name: r.name,
+          started_at: r.started_at,
+          completed_at: r.completed_at,
           external_id: r.external_id
         },
-        group_by: r.external_id,
         where: r.created_at > ^minimum_start_time,
-        order_by: [min(r.workflow_id), min(r.created_at)]
+        order_by: [r.workflow_id, r.created_at]
       )
       |> Repo.all()
       |> Enum.group_by(fn data -> data.name end)
       |> Enum.to_list()
-      |> Enum.sort_by(fn {_, run_jobs} ->
-        recent = run_jobs |> List.last()
+      |> Enum.sort_by(fn {_, runs} ->
+        recent = runs |> List.last()
         -DateTime.diff(recent.completed_at, recent.started_at)
       end)
 
     parts =
-      grouped_run_jobs
-      |> Enum.map(fn {name, _} -> List.last(name) end)
+      grouped_runs
+      |> Enum.map(fn {name, _} -> name end)
 
     colors = Helpers.generate_colors(parts |> Enum.count())
 
-    %{data: build_data(grouped_run_jobs, colors), colors: colors, parts: parts}
+    %{data: build_data(grouped_runs, colors), colors: colors, parts: parts}
   end
 
   def build_data([], []), do: []
 
-  def build_data([{part_name, run_jobs} | grouped_run_jobs], [color | colors]) do
+  def build_data([{part_name, run} | grouped_runs], [color | colors]) do
     [
       %{
         label: part_name,
         color: Helpers.build_style_color(color),
         data:
-          run_jobs
-          |> Enum.map(fn run_job ->
-            seconds = DateTime.diff(run_job.completed_at, run_job.started_at)
+          run
+          |> Enum.map(fn run ->
+            seconds = DateTime.diff(run.completed_at, run.started_at)
 
             %Part{
               name: part_name,
-              time: run_job.started_at,
+              time: run.started_at,
               seconds: seconds,
               minutes: seconds / 60,
-              link: link_from(run_job)
+              link: link_from(run)
             }
           end)
       }
-      | build_data(grouped_run_jobs, colors)
+      | build_data(grouped_runs, colors)
     ]
   end
 

--- a/lib/dashy/fetcher.ex
+++ b/lib/dashy/fetcher.ex
@@ -54,6 +54,7 @@ defmodule Dashy.Fetcher do
     save_function = &WorkflowRunJobs.create_or_update/1
 
     save_results(fetcher_module.get(repo_name, workflow_run.external_id), save_function)
+    WorkflowRuns.update_from_jobs(workflow_run.external_id)
   end
 
   defp save_results(results, save_function, attrs \\ %{}) do

--- a/lib/dashy/workflow_runs.ex
+++ b/lib/dashy/workflow_runs.ex
@@ -1,6 +1,9 @@
 defmodule Dashy.WorkflowRuns do
   alias Dashy.Repo
   alias Dashy.WorkflowRuns.WorkflowRun
+  alias Dashy.WorkflowRunJobs.WorkflowRunJob
+
+  import Ecto.Query
 
   def get_by_external_id(id), do: Repo.get_by(WorkflowRun, external_id: id)
 
@@ -11,5 +14,23 @@ defmodule Dashy.WorkflowRuns do
     end
     |> WorkflowRun.changeset(attrs)
     |> Repo.insert_or_update()
+  end
+
+  def update_from_jobs(external_id) do
+    attrs =
+      from(
+        j in WorkflowRunJob,
+        select: %{
+          started_at: min(j.started_at),
+          completed_at: max(j.completed_at)
+        },
+        where: j.workflow_run_id == ^external_id,
+        group_by: j.workflow_run_id
+      )
+      |> Repo.one()
+
+    get_by_external_id(external_id)
+    |> WorkflowRun.changeset(attrs)
+    |> Repo.update()
   end
 end

--- a/lib/dashy/workflow_runs/workflow_run.ex
+++ b/lib/dashy/workflow_runs/workflow_run.ex
@@ -10,6 +10,8 @@ defmodule Dashy.WorkflowRuns.WorkflowRun do
     field :conclusion, :string
     field :metadata, :map
     field :head_sha, :string
+    field :started_at, :utc_datetime
+    field :completed_at, :utc_datetime
 
     belongs_to :workflow, Dashy.Workflows.Workflow, references: :external_id
     timestamps(inserted_at: :created_at)
@@ -28,7 +30,9 @@ defmodule Dashy.WorkflowRuns.WorkflowRun do
       :conclusion,
       :workflow_id,
       :metadata,
-      :head_sha
+      :head_sha,
+      :started_at,
+      :completed_at
     ])
     |> validate_required([
       :external_id,

--- a/priv/repo/migrations/20210518085818_add_started_completed_to_workflow_runs.exs
+++ b/priv/repo/migrations/20210518085818_add_started_completed_to_workflow_runs.exs
@@ -1,0 +1,10 @@
+defmodule Dashy.Repo.Migrations.AddStartedCompletedToWorkflowRuns do
+  use Ecto.Migration
+
+  def change do
+    alter table("workflow_runs") do
+      add :started_at, :utc_datetime, null: true
+      add :completed_at, :utc_datetime, null: true
+    end
+  end
+end

--- a/test/dashy/charts/workflow_runs_test.exs
+++ b/test/dashy/charts/workflow_runs_test.exs
@@ -4,21 +4,19 @@ defmodule Dashy.Charts.WorkflowRunsTest do
   describe "runs/1" do
     test "lists all runs" do
       sha = "1"
-      run = insert(:workflow_run, head_sha: sha, created_at: ~U[2021-05-16 09:00:00Z])
-      run2 = insert(:workflow_run, head_sha: sha, created_at: ~U[2021-05-16 09:00:00Z])
 
-      insert(:workflow_run_job,
-        workflow_run: run,
+      insert(:workflow_run,
         head_sha: sha,
+        created_at: ~U[2021-05-16 09:00:00Z],
         started_at: ~U[2021-05-16 09:00:00Z],
         completed_at: ~U[2021-05-16 10:00:00Z],
         status: "completed",
         conclusion: "success"
       )
 
-      insert(:workflow_run_job,
-        workflow_run: run2,
+      insert(:workflow_run,
         head_sha: sha,
+        created_at: ~U[2021-05-16 09:00:00Z],
         started_at: ~U[2021-05-16 09:00:00Z],
         completed_at: ~U[2021-05-16 11:00:00Z],
         status: "completed",
@@ -37,21 +35,19 @@ defmodule Dashy.Charts.WorkflowRunsTest do
 
     test "handles the state correctly" do
       sha = "1"
-      run = insert(:workflow_run, head_sha: sha, created_at: ~U[2021-05-16 09:00:00Z])
-      run2 = insert(:workflow_run, head_sha: sha, created_at: ~U[2021-05-16 09:00:00Z])
 
-      insert(:workflow_run_job,
-        workflow_run: run,
+      insert(:workflow_run,
         head_sha: sha,
+        created_at: ~U[2021-05-16 09:00:00Z],
         started_at: ~U[2021-05-16 09:00:00Z],
         completed_at: ~U[2021-05-16 10:00:00Z],
         status: "completed",
         conclusion: "success"
       )
 
-      insert(:workflow_run_job,
-        workflow_run: run2,
+      insert(:workflow_run,
         head_sha: sha,
+        created_at: ~U[2021-05-16 09:00:00Z],
         started_at: ~U[2021-05-16 09:00:00Z],
         completed_at: ~U[2021-05-16 11:00:00Z],
         status: "completed",

--- a/test/dashy/repositories_test.exs
+++ b/test/dashy/repositories_test.exs
@@ -6,11 +6,11 @@ defmodule Dashy.RepositoriesTest do
   describe "repositories" do
     alias Dashy.Repositories.Repository
 
-    @valid_attrs %{name: "some name", user: "some user", branch: "some branch"}
+    @valid_attrs %{name: "some_name", user: "some_user", branch: "some_branch"}
     @update_attrs %{
-      name: "some updated name",
-      user: "some updated user",
-      branch: "some updated branch"
+      name: "some_updated_name",
+      user: "some_updated_user",
+      branch: "some_updated_branch"
     }
     @invalid_attrs %{name: nil, user: nil, branch: nil}
 
@@ -35,9 +35,10 @@ defmodule Dashy.RepositoriesTest do
 
     test "create_repository/1 with valid data creates a repository" do
       assert {:ok, %Repository{} = repository} = Repositories.create_repository(@valid_attrs)
-      assert repository.name == "some name"
-      assert repository.user == "some user"
-      assert repository.branch == "some branch"
+
+      assert repository.name == "some_name"
+      assert repository.user == "some_user"
+      assert repository.branch == "some_branch"
     end
 
     test "create_repository/1 with invalid data returns error changeset" do
@@ -50,9 +51,9 @@ defmodule Dashy.RepositoriesTest do
       assert {:ok, %Repository{} = repository} =
                Repositories.update_repository(repository, @update_attrs)
 
-      assert repository.name == "some updated name"
-      assert repository.user == "some updated user"
-      assert repository.branch == "some updated branch"
+      assert repository.name == "some_updated_name"
+      assert repository.user == "some_updated_user"
+      assert repository.branch == "some_updated_branch"
     end
 
     test "update_repository/2 with invalid data returns error changeset" do


### PR DESCRIPTION
## ✍️ Description

This PR adds the fields `started_at` and `created_at` to `WorkflowRun`s to simplify charts queries. 

## ✅ Fixes

(optional)

- Closes #(issue)
- Fixes #(issue)

## ✅ QA

Before requesting a review, please make sure that:

- [ ] Preview is working on Netlify, Heroku or similar.
- [ ] Manually check that it's working.
- [ ] Add documentation and tests if needed.

## 📸 Screenshots

(optional) Please post any relevant screenshots that might help understanding the scope of this functionality.

## 🔗 Relevant URLs

(optional)

* https://example.com/feature/1
* https://example.com/feature/2

## 📕Extra Documentation

(optional)

Please include links to any external documentation such as requirements, manuals, etc.
